### PR TITLE
Add environment variable support for client configuration

### DIFF
--- a/bin/tsds-output.py
+++ b/bin/tsds-output.py
@@ -117,15 +117,6 @@ class Client(object):
             self.url = environ[url_env_var]
 
 
-
-        print("testing env vars")
-
-        print("user = " + self.username)
-        print("pass = " + self.password)
-        print("url = " + self.url)
-        print("timeout = " + str(self.timeout))
-
-
         # Create a Session and Request object used for POSTing requests
         self.session      = Session()
         self.session.auth = (self.username, self.password)

--- a/bin/tsds-output.py
+++ b/bin/tsds-output.py
@@ -3,6 +3,7 @@ import sys, logging
 from yaml import load as load_yaml
 from json import loads as json_loads, dumps as json_dumps
 from re import match, escape
+from os import environ
 from requests import Session, Request
 
 ''' Log(config)
@@ -94,10 +95,36 @@ class Client(object):
 
     def __init__(self, config, log):
         
+        # get client information from client segment in config
         self.username = config.get('username')
         self.password = config.get('password')
         self.url      = config.get('url')
         self.timeout  = config.get('timeout')
+
+        # get environment variable names from same client segment
+        username_env_var = config.get('username_env_var')
+        password_env_var = config.get('password_env_var')
+        url_env_var      = config.get('url_env_var')
+
+        # override client info if environment vars are being used
+        if username_env_var in environ:
+            self.username = environ[username_env_var]
+
+        if password_env_var in environ:
+            self.password = environ[password_env_var]
+
+        if url_env_var in environ:
+            self.url = environ[url_env_var]
+
+
+
+        print("testing env vars")
+
+        print("user = " + self.username)
+        print("pass = " + self.password)
+        print("url = " + self.url)
+        print("timeout = " + str(self.timeout))
+
 
         # Create a Session and Request object used for POSTing requests
         self.session      = Session()

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -5,10 +5,13 @@ logging:
   file: '/path/to/logfile'
 
 # TSDS Push Service
-tsds:
-  url: "https://yourserver.com/tsds-basic/"
+client:
+  username_env_var: "PUSH_USER"
+  password_env_var: "PUSH_PASS"
+  url_env_var: "PUSH_URL"
   username: "username"
   password: "password"
+  url: "https://yourserver.com/tsds-basic/"
   timeout: 15
 
 # Collections of Telegraf Metric to TSDS Measurement Configurations


### PR DESCRIPTION
One piece of functionality we wanted was flexibility when it came to specifying the environment variables, so currently the plugin is set up to get client info (user, password, push url) from the config.yaml file, then override any of those fields if corresponding environment variables have been set.

We also thought it made sense to keep hard-coded environment variable names out of the python plugin and instead define them in the config.yaml file.

We've tested this both in plugin form and container form and haven't found any issues with this change.